### PR TITLE
Add rgba64 packing type

### DIFF
--- a/p2p.h
+++ b/p2p.h
@@ -360,6 +360,14 @@ using packed_argb64_be = byte_packed_444_be<uint16_t, uint64_t, make_mask(C_A, C
 using packed_argb64_le = byte_packed_444_le<uint16_t, uint64_t, make_mask(C_A, C_R, C_G, C_B)>;
 using packed_argb64 = endian_select<packed_argb64_be, packed_argb64_le>::type;
 
+using packed_rgba32_be = byte_packed_444_be<uint8_t, uint32_t, make_mask(C_R, C_G, C_B, C_A)>;
+using packed_rgba32_le = byte_packed_444_le<uint8_t, uint32_t, make_mask(C_R, C_G, C_B, C_A)>;
+using packed_rgba32 = endian_select<packed_rgba32_be, packed_rgba32_le>::type;
+
+using packed_rgba64_be = byte_packed_444_be<uint16_t, uint64_t, make_mask(C_R, C_G, C_B, C_A)>;
+using packed_rgba64_le = byte_packed_444_le<uint16_t, uint64_t, make_mask(C_R, C_G, C_B, C_A)>;
+using packed_rgba64 = endian_select<packed_rgba64_be, packed_rgba64_le>::type;
+
 // D3D A2R10G10B10.
 using packed_rgb30_be = pack_traits<
 	uint16_t, uint32_t, big_endian_t, 1, 0,

--- a/p2p_api.cpp
+++ b/p2p_api.cpp
@@ -49,6 +49,8 @@ const packing_traits traits_table[] = {
 	CASE2(p016, 1, 1, true, 2),
 	CASE2(p210, 1, 0, true, 2, 6),
 	CASE2(p216, 1, 0, true, 2),
+	CASE2(rgba32, 0, 0),
+	CASE2(rgba64, 0, 0),
 };
 #undef CASE2
 #undef CASE

--- a/p2p_api.h
+++ b/p2p_api.h
@@ -87,6 +87,14 @@ enum p2p_packing {
 	p2p_p216_be, /* NV21, big-endian components */
 	p2p_p216_le, /* NV12, little-endian components. Microsoft P216. */
 	p2p_p216,
+	/** [R8-G8-B8-A8] */
+	p2p_rgba32_be, /* RGBA */
+	p2p_rgba32_le, /* ABGR */
+	p2p_rgba32,
+	/** [R16-G16-B16-A16] */
+	p2p_rgba64_be, /* RGBA, big-endian components */
+	p2p_rgba64_le, /* ABGR, little-endian components */
+	p2p_rgba64,
 
 	p2p_packing_max,
 };


### PR DESCRIPTION
This is useful for packing/unpacking AV_PIX_FMT_RGBA64{LE,BE}.