### PR TITLE
Add various 16-bit RGBA packing types 

### DIFF
--- a/p2p.h
+++ b/p2p.h
@@ -368,6 +368,18 @@ using packed_rgba64_be = byte_packed_444_be<uint16_t, uint64_t, make_mask(C_R, C
 using packed_rgba64_le = byte_packed_444_le<uint16_t, uint64_t, make_mask(C_R, C_G, C_B, C_A)>;
 using packed_rgba64 = endian_select<packed_rgba64_be, packed_rgba64_le>::type;
 
+using packed_abgr64_be = byte_packed_444_be<uint16_t, uint64_t, make_mask(C_A, C_B, C_G, C_R)>;
+using packed_abgr64_le = byte_packed_444_le<uint16_t, uint64_t, make_mask(C_A, C_B, C_G, C_R)>;
+using packed_abgr64 = endian_select<packed_abgr64_be, packed_abgr64_le>::type;
+
+using packed_bgr48_be = byte_packed_444_be<uint16_t, detail::uint48, make_mask(C__, C_B, C_G, C_R)>;
+using packed_bgr48_le = byte_packed_444_le<uint16_t, detail::uint48, make_mask(C__, C_B, C_G, C_R)>;
+using packed_bgr48 = endian_select<packed_bgr48_be, packed_bgr48_le>::type;
+
+using packed_bgra64_be = byte_packed_444_be<uint16_t, uint64_t, make_mask(C_B, C_G, C_R, C_A)>;
+using packed_bgra64_le = byte_packed_444_le<uint16_t, uint64_t, make_mask(C_B, C_G, C_R, C_A)>;
+using packed_bgra64 = endian_select<packed_bgra64_be, packed_bgra64_le>::type;
+
 // D3D A2R10G10B10.
 using packed_rgb30_be = pack_traits<
 	uint16_t, uint32_t, big_endian_t, 1, 0,

--- a/p2p_api.cpp
+++ b/p2p_api.cpp
@@ -51,6 +51,9 @@ const packing_traits traits_table[] = {
 	CASE2(p216, 1, 0, true, 2),
 	CASE2(rgba32, 0, 0),
 	CASE2(rgba64, 0, 0),
+	CASE2(abgr64, 0, 0),
+	CASE2(bgr48, 0, 0),
+	CASE2(bgra64, 0, 0),
 };
 #undef CASE2
 #undef CASE

--- a/p2p_api.h
+++ b/p2p_api.h
@@ -95,6 +95,18 @@ enum p2p_packing {
 	p2p_rgba64_be, /* RGBA, big-endian components */
 	p2p_rgba64_le, /* ABGR, little-endian components */
 	p2p_rgba64,
+	/** [A16-B16-G16-R16] */
+	p2p_abgr64_be, /* ABGR, big-endian components */
+	p2p_abgr64_le, /* RGBA, little-endian components */
+	p2p_abgr64,
+	/** [B16-G16-R16] */
+	p2p_bgr48_be, /* BGR, big-endian components */
+	p2p_bgr48_le, /* RGB, little-endian components */
+	p2p_bgr48,
+	/** [B16-G16-R16-A16] */
+	p2p_bgra64_be, /* BGRA, big-endian components */
+	p2p_bgra64_le, /* ARGB, little-endian components */
+	p2p_bgra64,
 
 	p2p_packing_max,
 };


### PR DESCRIPTION
This is needed for unpacking AV_PIX_FMT_RGB48, which as R-G-B order,, and little endian components, for example.

All avcodec-output formats should now be covered.