### PR TITLE
Add meson build system

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,127 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+
+jobs:
+  run-tests:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-latest, windows-11-arm]
+        compiler: [g++, clang++, icx, msvc, clang-cl, msys2-gcc]
+        exclude:
+          # ---------- Linux ----------
+          - os: ubuntu-24.04-arm
+            compiler: icx
+          - os: ubuntu-24.04-arm
+            compiler: msvc
+          - os: ubuntu-24.04-arm
+            compiler: clang-cl
+          - os: ubuntu-24.04-arm
+            compiler: msys2-gcc
+
+          - os: ubuntu-latest
+            compiler: msvc
+          - os: ubuntu-latest
+            compiler: clang-cl
+          - os: ubuntu-latest
+            compiler: msys2-gcc
+
+          # ---------- macOS ----------
+          - os: macos-latest
+            compiler: g++
+          - os: macos-latest
+            compiler: icx
+          - os: macos-latest
+            compiler: msvc
+          - os: macos-latest
+            compiler: clang-cl
+          - os: macos-latest
+            compiler: msys2-gcc
+
+          - os: macos-15-intel
+            compiler: g++
+          - os: macos-15-intel
+            compiler: icx
+          - os: macos-15-intel
+            compiler: msvc
+          - os: macos-15-intel
+            compiler: clang-cl
+          - os: macos-15-intel
+            compiler: msys2-gcc
+
+          # ---------- Windows ----------
+          - os: windows-latest
+            compiler: g++
+          - os: windows-latest
+            compiler: clang++
+
+          - os: windows-11-arm
+            compiler: g++
+          - os: windows-11-arm
+            compiler: clang++
+          - os: windows-11-arm
+            compiler: icx
+          - os: windows-11-arm
+            compiler: msys2-gcc
+        include:
+          - compiler: g++
+            cxx: g++
+          - compiler: clang++
+            cxx: clang++
+          - compiler: msvc
+            cxx: cl
+          - compiler: clang-cl
+            cxx: clang-cl
+          - compiler: msys2-gcc
+            msys2: true
+
+
+    name: "Test (${{ matrix.os }}, ${{ matrix.compiler }})"
+    runs-on: ${{ matrix.os }}
+    env:
+      CXX: ${{ matrix.cxx }}
+
+    defaults:
+      run:
+        shell: ${{ matrix.msys2 == true && 'msys2 {0}' || 'bash' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Install ICX
+        if: matrix.compiler == 'icx'
+        uses: fortran-lang/setup-fortran@v1
+        with:
+          compiler: intel
+
+      - name: Setup MSYS2 (MINGW64)
+        if: matrix.msys2 == true
+        uses: msys2/setup-msys2@v2
+        with:
+          update: true
+          install: >-
+            mingw-w64-x86_64-ca-certificates
+            mingw-w64-x86_64-meson
+            mingw-w64-x86_64-toolchain
+
+      - name: Install Meson
+        if: matrix.msys2 != true
+        run: pip install meson
+
+      - name: Configure with Meson
+        run: >
+          meson setup builddir
+          --buildtype=release
+          -Dtest=enabled
+          ${{ (runner.arch == 'X86' || runner.arch == 'X64') && '-Dsimd=enabled' || '-Dsimd=disabled' }}
+          ${{ matrix.compiler == 'msvc' && '--vsenv' || '' }}
+
+      - name: Build
+        run: meson compile -C builddir --verbose
+
+      - name: Run tests
+        run: meson test -C builddir --verbose

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ Debug
 Release
 x64
 _msvc/.vs
+
+# Meson
+/subprojects/*
+!/subprojects/*.wrap

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,59 @@
+project(
+    'libp2p',
+    'cpp',
+    default_options: [
+        'cpp_std=c++14',
+        'buildtype=debugoptimized',
+    ],
+    license: 'WTFPL',
+    license_files: 'COPYING',
+    meson_version: '>= 1.1.0',
+)
+
+cpp = meson.get_compiler('cpp')
+
+incs = [include_directories('.')]
+
+install_headers(
+    files(
+        'p2p_api.h',
+        'p2p.h',
+    )
+)
+
+libp2p_src = files(
+    'p2p_api.cpp',
+    'v210.cpp',
+)
+
+cpp_public_defs = []
+cpp_compile_flags = []
+
+subdir('simd')
+
+libp2p = static_library(
+    'p2p',
+    libp2p_src,
+    cpp_args: cpp_public_defs + cpp_compile_flags,
+    include_directories: incs,
+    install: true,
+)
+
+libp2p_dep = declare_dependency(
+    link_with: libp2p,
+    include_directories: incs,
+    compile_args: cpp_public_defs
+)
+
+meson.override_dependency('libp2p', libp2p_dep)
+
+libp2p_pkg = import('pkgconfig')
+libp2p_pkg.generate(
+    name: meson.project_name(),
+    description: 'Pack/unpack pixels',
+    libraries: libp2p_dep,
+)
+
+if get_option('test').enabled()
+    subdir('test')
+endif

--- a/meson.options
+++ b/meson.options
@@ -1,0 +1,2 @@
+option('simd', type: 'feature', description: 'enable simd')
+option('test', type: 'feature', description: 'enable test')

--- a/simd/meson.build
+++ b/simd/meson.build
@@ -1,0 +1,36 @@
+incs += include_directories('.')
+
+install_headers(
+    files(
+        'cpuinfo_x86.h',
+        'p2p_simd.h',
+    ), 
+    subdir: 'simd'
+)
+
+libp2p_src += files(
+    'cpuinfo_x86.cpp',
+    'p2p_simd.cpp',
+    'p2p_sse41.cpp',
+)
+
+if get_option('simd').enabled()
+    cpu_family = host_machine.cpu_family()
+    if not cpu_family.startswith('x86')
+        error('SIMD support is only available for x86 CPU families.')
+    endif
+
+    cpp_public_defs += ['-DP2P_SIMD']
+
+    if cpp.get_argument_syntax() == 'gcc'
+        cpp_compile_flags += ['-msse4.1']
+    elif cpp.get_argument_syntax() == 'msvc'
+        if cpp.get_id() == 'clang-cl'
+            cpp_compile_flags += ['/clang:-msse4.1']
+        else
+            cpp_compile_flags += ['/arch:AVX2']
+        endif
+    else
+        error('Your compiler, ' + cpp.get_id() + ', does not seem to support SIMD.')
+    endif
+endif

--- a/subprojects/gtest.wrap
+++ b/subprojects/gtest.wrap
@@ -1,0 +1,16 @@
+[wrap-file]
+directory = googletest-1.15.2
+source_url = https://github.com/google/googletest/archive/refs/tags/v1.15.2.tar.gz
+source_filename = gtest-1.15.2.tar.gz
+source_hash = 7b42b4d6ed48810c5362c265a17faebe90dc2373c885e5216439d37927f02926
+patch_filename = gtest_1.15.2-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/gtest_1.15.2-4/get_patch
+patch_hash = a5151324b97e6a98fa7a0e8095523e6d5c4bb3431210d6ac4ad9800c345acf40
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/gtest_1.15.2-4/gtest-1.15.2.tar.gz
+wrapdb_version = 1.15.2-4
+
+[provide]
+gtest = gtest_dep
+gtest_main = gtest_main_dep
+gmock = gmock_dep
+gmock_main = gmock_main_dep

--- a/test/api_test.cpp
+++ b/test/api_test.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <vector>
 #include "p2p_api.h"

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,18 @@
+test_src = [
+  'api_formats_test.cpp',
+  'api_test.cpp',
+  'v210_test.cpp',
+]
+
+if get_option('simd').enabled()
+    test_src += ['simd_test.cpp']
+endif
+
+gtest_main_dep = dependency('gtest_main')
+
+test_prog = executable(
+    'testprog',
+    test_src,
+    dependencies : [gtest_main_dep, libp2p_dep],
+)    
+test('gtest test', test_prog)

--- a/test/simd_test.cpp
+++ b/test/simd_test.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <array>
 #include <cstring>
 #include <random>


### PR DESCRIPTION
This PR introduces [Meson](https://mesonbuild.com/) as the primary build system for the project, replacing both Makefiles (on Unix-like systems) and MSBuild (on Windows). The goal is to simplify the build process, improve cross-platform support, and reduce maintenance overhead associated with multiple build systems.